### PR TITLE
fixed the masking for drop_nans=False

### DIFF
--- a/craftroom/resample.py
+++ b/craftroom/resample.py
@@ -180,7 +180,7 @@ def bintogrid(x, y, unc=None, newx=None, dx=None, weighting='inversevariance', d
 	if drop_nans:
 		ok = np.isfinite(newy)
 	else:
-		ok = np.ones_like(x).astype(np.bool)
+		ok = np.ones_like(newy).astype(np.bool)
 	# return binned x, y, unc
 	if unc is None:
 		return newx[ok], newy[ok]


### PR DESCRIPTION
Hi Zach, noticed a bug where if you request drop_nans=False, the boolean array "ok" is made to the length of the input grid, not the new grid. 